### PR TITLE
type:fix

### DIFF
--- a/punchcard.py
+++ b/punchcard.py
@@ -140,6 +140,10 @@ class Chart(sizers.Box):
         size = self.model.cell_size
         lo = min(x for row in data for x in row if x)
         hi = max(x for row in data for x in row if x)
+        
+        if hi == lo:
+            lo = 0.
+            
         min_area = pi * (self.model.min_size / 2.0) ** 2
         max_area = pi * (self.model.max_size / 2.0) ** 2
         min_color = self.model.min_color


### PR DESCRIPTION
fixed the issue with binary matrices (only 0s and 1s) by adding the check to `hi` and `lo`

explanation:
when the `.csv` contains a binary matrix as this one
```
,1,2,3
Monday,0,1,0,0
Tuesday,0,0,0
Wednesday,0,1,1
Thursday,0,0,0
Friday,0,1,0
Saturday,1,0,0
Sunday,1,1,1
```
the script fails at finding two different values for `hi` and `lo` variables. This in turn causes a `ZeroDivisionError: float division by zero` during execution.

I fixed this issue by forcing `lo=0.` in the case it has the same value of `hi`.